### PR TITLE
Continue investigating ongoing issue

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -4,14 +4,9 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
-    # Include standard MIME types
-    include /etc/nginx/mime.types;
-
-    # Add WASM and PCAP MIME types (not in standard mime.types)
-    types {
-        application/wasm wasm;
-        application/vnd.tcpdump.pcap pcap;
-    }
+    # MIME types are inherited from the parent http block in nginx.conf
+    # which already includes /etc/nginx/mime.types
+    # DO NOT add a types {} block here - it would REPLACE all inherited types!
 
     # Gzip compression for text-based content
     gzip on;
@@ -34,13 +29,23 @@ server {
     }
 
     # Cache static assets
-    location ~* \.(js|css|wasm|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # WASM files - set explicit MIME type (may not be in older mime.types)
+    location ~* \.wasm$ {
+        types { }
+        default_type application/wasm;
         expires 1y;
         add_header Cache-Control "public, immutable";
     }
 
     # PCAP files - allow download but don't cache long
     location ~* \.pcap$ {
+        types { }
+        default_type application/vnd.tcpdump.pcap;
         expires 1h;
         add_header Cache-Control "public";
     }


### PR DESCRIPTION
The types {} block at server level was REPLACING all inherited MIME types (including text/html for .html files), not adding to them. This caused HTML to be served as application/octet-stream.

Fix: Remove the types block from server context and rely on the parent http block's mime.types. Use location-specific default_type for wasm and pcap files.