### PR TITLE
Convert JSON detail view to tree widget

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,6 +741,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "egui_json_tree"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef3b2a7696ccb992eb7a4e657bd13b147505e0f6e42a44e8de7f0359e301b0fa"
+dependencies = [
+ "egui",
+ "serde_json",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2723,6 +2733,7 @@ dependencies = [
  "anyhow",
  "console_error_panic_hook",
  "eframe",
+ "egui_json_tree",
  "js-sys",
  "log",
  "serde",

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -16,6 +16,7 @@ eframe = { version = "0.29", default-features = false, features = [
     "default_fonts",
     "glow",
 ] }
+egui_json_tree = "0.7"
 log = "0.4"
 
 # Web-specific dependencies


### PR DESCRIPTION
Use egui_json_tree to display message and packet details as collapsible tree structures instead of plain pretty-printed JSON text. This provides better navigation for deeply nested AC protocol data structures.