### PR TITLE
Investigate deployment SHA mismatch issue

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
+      - name: Force rebuild of web crate (embeds git SHA)
+        run: |
+          # Clean web crate build artifacts to ensure build.rs runs with current SHA
+          rm -rf target/wasm32-unknown-unknown/release/web.wasm
+          rm -rf target/wasm32-unknown-unknown/release/.fingerprint/web-*
+          rm -rf target/wasm32-unknown-unknown/release/deps/web-*
+
       - name: Install wasm-bindgen-cli
         run: |
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH


### PR DESCRIPTION
The cargo cache was preserving compiled artifacts with stale git SHAs embedded. Even though build.rs uses cargo:rerun-if-changed=.git/HEAD, the cached fingerprint prevented rebuild. This adds a step to clean the web crate's build artifacts before building, ensuring the current SHA is always embedded.