### PR TITLE
Add URL query parameter support for loading PCAP files

### DIFF
--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -37,6 +37,9 @@ web-sys = { version = "0.3", features = [
     "Request",
     "RequestInit",
     "Response",
+    "Location",
+    "Url",
+    "UrlSearchParams",
 ] }
 js-sys = "0.3"
 console_error_panic_hook = "0.1"


### PR DESCRIPTION
Allow loading PCAP files via URL query parameter (?url=...) so users can
share direct links to specific captures. The app now checks for a 'url'
query parameter on startup and automatically fetches and loads the PCAP.

- Add Location, Url, UrlSearchParams features to web-sys
- Add get_url_from_query_params() to parse URL from query string
- Add load_from_url() method for fetching from arbitrary URLs
- Refactor load_example() to reuse load_from_url()
- Auto-load from URL on first frame if parameter present