### PR TITLE
Scale mobile sizes based on viewport breakpoint

### DIFF
--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -26,8 +26,8 @@ enum SortField {
 const MOBILE_BREAKPOINT: f32 = 768.0;
 const TABLET_BREAKPOINT: f32 = 1024.0;
 
-// Mobile UI scaling (2x for debugging, adjust as needed)
-const MOBILE_SCALE: f32 = 2.0;
+// Mobile UI scaling factor
+const MOBILE_SCALE: f32 = 1.5;
 
 // Shared state for async loading
 type SharedData = Arc<Mutex<Option<Vec<u8>>>>;


### PR DESCRIPTION
Use egui's set_pixels_per_point() to scale up UI elements (fonts, bars, etc.) when viewport width is below the mobile breakpoint. The base pixels_per_point is stored on first frame to correctly detect mobile regardless of current scaling state.

Currently set to 2x scale for debugging purposes - adjust MOBILE_SCALE constant as needed.