### PR TITLE
Check API usage and quota limits

### DIFF
--- a/crates/web/src/time_scrubber.rs
+++ b/crates/web/src/time_scrubber.rs
@@ -184,7 +184,8 @@ impl TimeScrubber {
                 };
 
                 for (time, density) in &self.density_data {
-                    let x = rect.min.x + ((*time - data_range.min) / time_range) as f32 * rect.width();
+                    let x =
+                        rect.min.x + ((*time - data_range.min) / time_range) as f32 * rect.width();
                     let normalized_density = density / max_density;
                     let bar_height = normalized_density * height;
 


### PR DESCRIPTION
The density visualization was drawing unwanted lines from peaks back to origin because the fill path was explicitly adding the first point again at the end. Since we're using closed=false on the PathShape, we don't need to manually close back to the starting point.

Fix: Remove the line that adds first_point back to fill_points after going along the bottom. The polygon now correctly fills the area under the density curve without any lines going back to 0,0.