### PR TITLE
Add URL loading option to PCAP file pane

### DIFF
--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -947,9 +947,9 @@ impl eframe::App for PcapViewerApp {
                     } else {
                         "Drop a PCAP anywhere in the window"
                     });
-                    ui.add_space(if is_mobile { 10.0 } else { 10.0 });
+                    ui.add_space(10.0);
                     ui.label("or");
-                    ui.add_space(if is_mobile { 10.0 } else { 10.0 });
+                    ui.add_space(10.0);
 
                     let button_size = if is_mobile {
                         [150.0, 35.0]


### PR DESCRIPTION
Add a clickable "Load from URL..." button on the main landing page alongside the existing "Load Example" button. This provides users with an easy way to load PCAP files from URLs without using the menu bar.

The button opens the existing URL dialog, maintaining consistency with the File > Open > From URL menu option. This complements the existing ?url= query parameter support for direct URL loading.