### PR TITLE
Move scrubber below list and main pane

### DIFF
--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -804,37 +804,6 @@ impl eframe::App for PcapViewerApp {
             });
         });
 
-        // Time scrubber panel (only show if we have data)
-        // Show appropriate scrubber based on current tab
-        let mut clicked_time: Option<f64> = None;
-        if has_data {
-            // Check which scrubber has data
-            let scrubber_has_data = match self.current_tab {
-                Tab::Messages => self.messages_scrubber.has_data(),
-                Tab::Fragments => self.fragments_scrubber.has_data(),
-            };
-
-            if scrubber_has_data {
-                egui::TopBottomPanel::top("time_scrubber_panel")
-                    .resizable(false)
-                    .show(ctx, |ui| {
-                        // Show appropriate scrubber
-                        let result = match self.current_tab {
-                            Tab::Messages => self.messages_scrubber.show(ui),
-                            Tab::Fragments => self.fragments_scrubber.show(ui),
-                        };
-
-                        // Check if user clicked
-                        if result.is_some() {
-                            clicked_time = match self.current_tab {
-                                Tab::Messages => self.messages_scrubber.get_hover_time(),
-                                Tab::Fragments => self.fragments_scrubber.get_hover_time(),
-                            };
-                        }
-                    });
-            }
-        }
-
         // Detail panel - responsive layout:
         // Mobile: Bottom panel (stacked vertically below list)
         // Desktop/Tablet: Right side panel (side by side)
@@ -898,6 +867,38 @@ impl eframe::App for PcapViewerApp {
                             .show(ui, |ui| {
                                 self.show_detail_content(ui);
                             });
+                    });
+            }
+        }
+
+        // Time scrubber panel (only show if we have data)
+        // Show appropriate scrubber based on current tab
+        // This panel is shown BELOW the central panel (list/detail pane)
+        let mut clicked_time: Option<f64> = None;
+        if has_data {
+            // Check which scrubber has data
+            let scrubber_has_data = match self.current_tab {
+                Tab::Messages => self.messages_scrubber.has_data(),
+                Tab::Fragments => self.fragments_scrubber.has_data(),
+            };
+
+            if scrubber_has_data {
+                egui::TopBottomPanel::bottom("time_scrubber_panel")
+                    .resizable(false)
+                    .show(ctx, |ui| {
+                        // Show appropriate scrubber
+                        let result = match self.current_tab {
+                            Tab::Messages => self.messages_scrubber.show(ui),
+                            Tab::Fragments => self.fragments_scrubber.show(ui),
+                        };
+
+                        // Check if user clicked
+                        if result.is_some() {
+                            clicked_time = match self.current_tab {
+                                Tab::Messages => self.messages_scrubber.get_hover_time(),
+                                Tab::Fragments => self.fragments_scrubber.get_hover_time(),
+                            };
+                        }
                     });
             }
         }


### PR DESCRIPTION
The time scrubber component has been relocated from a top panel position to a bottom panel position, placing it below the main content area (list and json/binary detail pane) but above the status bar.

This change improves the UI layout by:
- Keeping the timeline visualization closer to the status bar
- Giving more vertical space to the main content area
- Maintaining logical grouping of temporal navigation at the bottom

Changes:
- Changed time_scrubber_panel from TopBottomPanel::top to TopBottomPanel::bottom
- Repositioned panel declaration to occur before CentralPanel but after detail panels
- Updated comments to reflect the new layout position