### PR TITLE
Fix: Use consistent filter logic for scrubber highlighting

### DIFF
--- a/crates/app/src/ui/packet_list.rs
+++ b/crates/app/src/ui/packet_list.rs
@@ -223,16 +223,45 @@ pub fn show_messages_list(app: &mut PcapViewerApp, ui: &mut egui::Ui, is_mobile:
 
     // Collect timestamps of messages matching search (for highlighting on scrubber)
     if !search.is_empty() {
+        let filters = parse_filter_string(&search);
         let search_matched_timestamps: Vec<f64> = app
             .messages
             .iter()
             .filter(|m| {
-                let id_matches = m.id.to_string().contains(&search);
-                let type_matches = m.message_type.to_lowercase().contains(&search);
-                let direction_matches = m.direction.to_lowercase().contains(&search);
-                let opcode_matches = m.opcode.to_lowercase().contains(&search);
-                let data_matches = json_contains_string(&m.data, &search);
-                id_matches || type_matches || direction_matches || opcode_matches || data_matches
+                // Use the same matching logic as the table filtering
+                let mut matches = false;
+
+                // Search in message ID
+                if matches_any_filter(&filters, &m.id.to_string()) {
+                    matches = true;
+                }
+
+                // Check opcode match
+                if !matches && matches_any_filter(&filters, &m.opcode) {
+                    matches = true;
+                }
+
+                // Check direction match
+                if !matches && matches_any_filter(&filters, &m.direction) {
+                    matches = true;
+                }
+
+                // Check if filter matches in data fields
+                if !matches {
+                    let data_str = serde_json::to_string(&m.data).unwrap_or_default();
+                    if matches_any_filter(&filters, &data_str) {
+                        matches = true;
+                    }
+                }
+
+                // Always also do text search (type and data)
+                if !matches {
+                    let type_matches = m.message_type.to_lowercase().contains(&search);
+                    let data_matches = json_contains_string(&m.data, &search);
+                    matches = type_matches || data_matches;
+                }
+
+                matches
             })
             .map(|m| m.timestamp)
             .collect();


### PR DESCRIPTION
- Scrubber highlighting now uses the same rich filter logic as table filtering and marking
- Hex searches (e.g., 0xF7E0) now show yellow marks on scrubber pane
- All three systems (table filter, scrubber highlights, marking) now use identical matching logic