### PR TITLE
Remove fragments tab from GUI

### DIFF
--- a/crates/app/src/ui/file_panel.rs
+++ b/crates/app/src/ui/file_panel.rs
@@ -1,6 +1,6 @@
 //! File loading and management UI components
 
-use crate::{PcapViewerApp, Tab};
+use crate::PcapViewerApp;
 use eframe::egui;
 use lib::PacketParser;
 
@@ -365,21 +365,7 @@ pub fn show_settings_dialog(app: &mut PcapViewerApp, ctx: &egui::Context) {
             ui.heading("Default View");
             ui.separator();
 
-            ui.horizontal(|ui| {
-                ui.label("Default Tab:");
-                if ui
-                    .selectable_label(app.current_tab == Tab::Messages, "Messages")
-                    .clicked()
-                {
-                    app.current_tab = Tab::Messages;
-                }
-                if ui
-                    .selectable_label(app.current_tab == Tab::Fragments, "Fragments")
-                    .clicked()
-                {
-                    app.current_tab = Tab::Fragments;
-                }
-            });
+            // Default tab is always Messages (no selection needed)
 
             ui.horizontal(|ui| {
                 ui.label("Sort Order:");

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -46,7 +46,6 @@ impl Serialize for Direction {
 pub enum Tab {
     #[default]
     Messages,
-    Fragments,
     Weenies,
 }
 


### PR DESCRIPTION
- Remove Fragments variant from Tab enum in lib crate
- Update GUI app to remove all Fragments tab references
- Update detail panel to only handle Messages view
- Update file panel to remove Fragments tab option
- Update TUI to remove Fragments tab and navigation
- Keep CLI fragments subcommand for export functionality
- Remove unused code (packet rendering, fragment state)
- Pass all formatting, linting, and tests